### PR TITLE
Disable ticket validation when NO_AUTH is set

### DIFF
--- a/lib/cassette/authentication/filter.rb
+++ b/lib/cassette/authentication/filter.rb
@@ -20,7 +20,7 @@ module Cassette::Authentication::Filter
   def validate_authentication_ticket(service = Cassette.config.service)
     ticket = request.headers['Service-Ticket'] || params[:ticket]
 
-    if ENV['NOAUTH'] && !ticket
+    if ENV['NOAUTH']
       Cassette.logger.debug 'NOAUTH set and no Service Ticket, skipping authentication'
       self.current_user = Cassette::Authentication::User.new
       return

--- a/spec/cassette/authentication/filter_spec.rb
+++ b/spec/cassette/authentication/filter_spec.rb
@@ -97,20 +97,25 @@ describe Cassette::Authentication::Filter do
     end
   end
 
+
   describe '#validate_authentication_ticket' do
+    shared_examples_for 'controller without authentication' do
+      it 'does not validate tickets' do
+        controller.validate_authentication_ticket
+        expect(Cassette::Authentication).not_to have_received(:validate_ticket)
+      end
+
+      it 'sets current_user' do
+        controller.validate_authentication_ticket
+        expect(controller.current_user).to be_present
+      end
+    end
+
     it_behaves_like 'with NOAUTH' do
       context 'and no ticket' do
         let(:controller) { ControllerMock.new }
 
-        it 'should not validate tickets' do
-          controller.validate_authentication_ticket
-          expect(Cassette::Authentication).not_to have_received(:validate_ticket)
-        end
-
-        it 'should set current_user' do
-          controller.validate_authentication_ticket
-          expect(controller.current_user).to be_present
-        end
+        it_behaves_like 'controller without authentication'
       end
 
       context 'and a ticket header' do
@@ -118,10 +123,7 @@ describe Cassette::Authentication::Filter do
           ControllerMock.new({}, 'Service-Ticket' => 'le ticket')
         end
 
-        it 'should validate tickets' do
-          controller.validate_authentication_ticket
-          expect(Cassette::Authentication).to have_received(:validate_ticket).with('le ticket', Cassette.config.service)
-        end
+        it_behaves_like 'controller without authentication'
       end
 
       context 'and a ticket param' do
@@ -129,10 +131,7 @@ describe Cassette::Authentication::Filter do
           ControllerMock.new(ticket: 'le ticket')
         end
 
-        it 'should validate tickets' do
-          controller.validate_authentication_ticket
-          expect(Cassette::Authentication).to have_received(:validate_ticket).with('le ticket', Cassette.config.service)
-        end
+        it_behaves_like 'controller without authentication'
       end
     end
 


### PR DESCRIPTION
This MR allows one to fully disable CAS authentication, regardless of having a ticket within the request.