### PR TITLE
Improve separation of concerns

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,15 +15,19 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    addressable (2.3.8)
     ast (2.0.0)
     astrolabe (1.3.0)
       parser (>= 2.2.0.pre.3, < 3.0)
     builder (3.2.2)
     coderay (1.1.0)
+    crack (0.4.2)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
+    hashdiff (0.2.3)
     i18n (0.7.0)
     json (1.8.2)
     libxml-ruby (2.8.0)
@@ -66,6 +70,7 @@ GEM
     ruby-progressbar (1.7.1)
     rubycas-client (2.3.9)
       activesupport
+    safe_yaml (1.0.4)
     simplecov (0.9.2)
       docile (~> 1.1.0)
       multi_json (~> 1.0)
@@ -79,6 +84,10 @@ GEM
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    webmock (1.22.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
@@ -94,3 +103,7 @@ DEPENDENCIES
   simplecov
   simplecov-gem-adapter
   simplecov-rcov
+  webmock
+
+BUNDLED WITH
+   1.10.6

--- a/cassette.gemspec
+++ b/cassette.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'simplecov-rcov'
   gem.add_development_dependency 'simplecov-gem-adapter'
   gem.add_development_dependency 'rspec_junit_formatter'
+  gem.add_development_dependency 'webmock'
 
   gem.files         = %w(README.md) + Dir['lib/**/*'] + Dir['spec/**/*']
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }

--- a/lib/cassette.rb
+++ b/lib/cassette.rb
@@ -43,29 +43,5 @@ module Cassette
     @@config = config
   end
 
-  def new_request(uri, timeout)
-    Faraday.new(url: uri, ssl: { verify: false, version: 'TLSv1' }) do |builder|
-      builder.adapter Faraday.default_adapter
-      builder.options.timeout = timeout
-    end
-  end
-
-  def post(uri, payload, timeout = DEFAULT_TIMEOUT)
-    perform(:post, uri, timeout) do |req|
-      req.body = URI.encode_www_form(payload)
-      logger.debug "Request: #{req.inspect}"
-    end
-  end
-
-  protected
-
-  def perform(op, uri, timeout = DEFAULT_TIMEOUT, &block)
-    request = new_request(uri, timeout)
-    res = request.send(op, &block)
-
-    res.tap do |response|
-      logger.debug "Got response: #{response.body.inspect} (#{response.status}), #{response.headers.inspect}"
-      Cassette::Errors.raise_by_code(response.status) unless response.success?
-    end
-  end
+  delegate :post, to: :'Http::Request'
 end

--- a/lib/cassette.rb
+++ b/lib/cassette.rb
@@ -2,6 +2,7 @@
 
 require 'cassette/errors'
 require 'cassette/cache'
+require 'cassette/http'
 require 'cassette/client/cache'
 require 'cassette/client'
 require 'cassette/authentication'

--- a/lib/cassette/http.rb
+++ b/lib/cassette/http.rb
@@ -1,5 +1,6 @@
 require_relative 'http/request'
 require_relative 'http/parsed_response'
+require_relative 'http/ticket_response'
 
 module Cassette
   module Http

--- a/lib/cassette/http.rb
+++ b/lib/cassette/http.rb
@@ -1,0 +1,6 @@
+require_relative 'http/request'
+
+module Cassette
+  module Http
+  end
+end

--- a/lib/cassette/http.rb
+++ b/lib/cassette/http.rb
@@ -1,4 +1,5 @@
 require_relative 'http/request'
+require_relative 'http/parsed_response'
 
 module Cassette
   module Http

--- a/lib/cassette/http/parsed_response.rb
+++ b/lib/cassette/http/parsed_response.rb
@@ -1,0 +1,20 @@
+require 'delegate'
+require 'active_support/xml_mini'
+
+module Cassette
+  module Http
+    class ParsedResponse < SimpleDelegator
+      def initialize(raw_content, parser = XMLParser)
+        super(parser.call(raw_content))
+      end
+
+      XMLParser = lambda do |raw_content|
+        ActiveSupport::XmlMini.with_backend('LibXML') do
+          ActiveSupport::XmlMini.parse(raw_content)
+        end
+      end
+
+      private_constant :XMLParser
+    end
+  end
+end

--- a/lib/cassette/http/request.rb
+++ b/lib/cassette/http/request.rb
@@ -1,0 +1,44 @@
+module Cassette
+  module Http
+    module Request
+      extend self
+
+      def post(uri, payload, timeout = DEFAULT_TIMEOUT)
+        perform(:post, uri, timeout) do |request|
+          request.body = URI.encode_www_form(payload)
+        end
+      end
+
+      private
+
+      def perform(http_verb, uri, timeout, &block)
+        request(uri, timeout)
+          .tap(&log_request)
+          .public_send(http_verb, &block)
+          .tap(&check_response)
+      end
+
+      def request(uri, timeout)
+        Faraday.new(url: uri, ssl: { verify: false, version: 'TLSv1' }) do |con|
+          con.adapter Faraday.default_adapter
+          con.options.timeout = timeout
+        end
+      end
+
+      def log_request
+        -> (request) { Cassette.logger.debug "Request: #{request.inspect}" }
+      end
+
+      def check_response
+        lambda do |resp|
+          Cassette.logger.debug(
+            "Got response: #{resp.body.inspect} (#{resp.status}), " \
+            "#{resp.headers.inspect}"
+          )
+
+          Cassette::Errors.raise_by_code(resp.status) unless resp.success?
+        end
+      end
+    end
+  end
+end

--- a/lib/cassette/http/ticket_response.rb
+++ b/lib/cassette/http/ticket_response.rb
@@ -1,0 +1,48 @@
+module Cassette
+  module Http
+    class TicketResponse
+      def initialize(response)
+        @content = ParsedResponse.new(response)
+      end
+
+      def login
+        fetch_val(
+          content,
+          'serviceResponse',
+          'authenticationSuccess',
+          'user',
+          '__content__'
+        )
+      end
+
+      def name
+        fetch_val(attributes, 'cn', '__content__')
+      end
+
+      def authorities
+        fetch_val(attributes, 'authorities', '__content__')
+      end
+
+      private
+
+      attr_reader :content
+
+      def fetch_val(hash, *keys)
+        keys.reduce(hash, &access_key)
+      end
+
+      def access_key
+        -> (hash, key) { hash.try(:[], key) }
+      end
+
+      def attributes
+        fetch_val(
+          content,
+          'serviceResponse',
+          'authenticationSuccess',
+          'attributes'
+        )
+      end
+    end
+  end
+end

--- a/spec/cassette/http/parsed_response_spec.rb
+++ b/spec/cassette/http/parsed_response_spec.rb
@@ -1,0 +1,27 @@
+describe Cassette::Http::ParsedResponse do
+  subject(:parsed_response) { described_class.new(xml_response) }
+
+  let(:xml_response) { fixture('cas/success.xml') }
+
+  let(:hash_response) do
+    {
+      "serviceResponse" => {
+        "authenticationSuccess" => {
+          "user"=> {
+            "__content__" => "test-user"
+          },
+          "attributes" => {
+            "authorities" => {
+              "__content__" => "[CUPOM, AUDITING,]"
+            },
+            "cn" => {
+              "__content__" => "Test System"
+            }
+          }
+        }
+      }
+    }
+  end
+
+  it { is_expected.to eq(hash_response) }
+end

--- a/spec/cassette/http/request_spec.rb
+++ b/spec/cassette/http/request_spec.rb
@@ -1,0 +1,41 @@
+describe Cassette::Http::Request do
+  subject(:request) { described_class }
+
+  describe '.post' do
+    subject(:post) { request.post(uri, payload) }
+
+    let(:uri) { 'http://example.org/' }
+    let(:payload) { { ping: :pong } }
+    let(:response) do
+      {
+        headers: { 'Content-Type' => 'application/json' },
+        body: { ok: :true }.to_json,
+        status: 200
+      }
+    end
+
+    before { stub_request(:post, uri).to_return(response) }
+
+    it 'performs a http post request with the proper params'do
+      post
+
+      expect(a_request(:post, uri).with(body: 'ping=pong')).to have_been_made
+    end
+
+    it do
+      is_expected.to have_attributes(
+        headers: { 'Content-Type' => 'application/json' },
+        body: '{"ok":"true"}',
+        status: 200
+      )
+    end
+
+    context 'when response has an error status code' do
+      let(:response) { { status: 500 } }
+
+      it 'raises an exception' do
+        expect { post }.to raise_error(Cassette::Errors::InternalServerError)
+      end
+    end
+  end
+end

--- a/spec/cassette/http/ticket_response_spec.rb
+++ b/spec/cassette/http/ticket_response_spec.rb
@@ -1,0 +1,41 @@
+describe Cassette::Http::TicketResponse do
+  subject(:ticket_response) { described_class.new(xml_response) }
+
+  let(:xml_response) { fixture('cas/success.xml') }
+
+  describe '#login' do
+    subject(:login) { ticket_response.login }
+
+    it { is_expected.to eq('test-user') }
+
+    context "when response isn't successful"  do
+      let(:xml_response) { fixture('cas/fail.xml') }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#name' do
+    subject(:name) { ticket_response.name }
+
+    it { is_expected.to eq('Test System') }
+
+    context "when response isn't successful"  do
+      let(:xml_response) { fixture('cas/fail.xml') }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#authorities' do
+    subject(:authorities) { ticket_response.authorities }
+
+    it { is_expected.to eq('[CUPOM, AUDITING,]') }
+
+    context "when response isn't successful"  do
+      let(:xml_response) { fixture('cas/fail.xml') }
+
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/cassette_spec.rb
+++ b/spec/cassette_spec.rb
@@ -1,48 +1,6 @@
 require 'spec_helper'
 
 describe Cassette do
-  let(:uri) { 'http://example.org/' }
-  let(:response) do
-    Faraday.new do |builder|
-      builder.adapter :test do |stub|
-        stub.post(uri, 'ping=pong') do |env|
-          headers = env.request_headers
-          [200, {}, '{ok: true}']
-        end
-      end
-    end
-  end
-
-  let(:failed_response) do
-    Faraday.new do |builder|
-      builder.adapter :test do |stub|
-        stub.post(uri, 'ping=pong') do |env|
-          headers = env.request_headers
-          [500, {}, '{ok: false}']
-        end
-      end
-    end
-  end
-
-  describe '.new_request' do
-    it 'returns an instance' do
-      # damn coverage
-      expect(Cassette.new_request(uri, 5)).to be_instance_of(Faraday::Connection)
-    end
-  end
-
-  describe '.post' do
-    it 'forwards requests' do
-      allow(Cassette).to receive(:new_request).with(uri, 5).and_return(response)
-      Cassette.post(uri, { ping: :pong }, 5)
-    end
-
-    it 'raises an exception when failed' do
-      allow(Cassette).to receive(:new_request).with(uri, 5).and_return(failed_response)
-      expect { Cassette.post(uri, { ping: :pong }, 5) }.to raise_error(Cassette::Errors::InternalServerError)
-    end
-  end
-
   def keeping_logger(&block)
     original_logger = Cassette.logger
     block.call

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require 'simplecov'
 require 'simplecov-rcov'
 require 'simplecov-gem-adapter'
 require 'yaml'
+require 'webmock/rspec'
 
 module Fixtures
   def fixture(name)


### PR DESCRIPTION
This MR is merely an attempt to enhance code organization by improving the separation of concerns in a few classes.

* Move HTTP request methods to `Cassette::Http::Request`;
* Decouple tests from `Faraday`;
* Create `Cassette::Http::ParsedResponse`
* Create `Cassette::Http::TicketResponse`