### PR TITLE
Fixed deprecated method before_filter for Rails 5 applications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.1.4] - 2017-07-03
+### Fixed
+- Fixed deprecated method before_filter for Rails 5 applications
+
 ## [1.1.3] - 2016-05-13
 ## Changed
 - Memoizes Faraday instances to keep the number of file descriptors down

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cassette (1.1.3)
+    cassette (1.1.4)
       activesupport (> 3.1.0)
       faraday (> 0.9)
       libxml-ruby
@@ -113,4 +113,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.12.3
+   1.15.1

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ class SomeController < ApplicationController
 end
 ```
 
-Where options are the same options you can pass to Rails' `skip_before_filter` method.
+Where options are the same options you can pass to Rails' `skip_before_action` method.
 
 You also can skip the whole CAS authentication using an environment variable `NOAUTH=true`. The method `current_user` will keep available. This is useful for development environments. **Be careful not to set and/or forget this variable in production environment**.
 
@@ -139,7 +139,7 @@ class SomeController < ApplicationController
 
     # - Allow only employees:
     #
-    # before_filter :employee_only_filter
+    # before_action :employee_only_filter
     #
     # rescue_from Cassette::Errors::NotAnEmployee do
     #   redirect_to '/403.html'
@@ -147,7 +147,7 @@ class SomeController < ApplicationController
 
     # - Allow only customers:
     #
-    # before_filter :customer_only_filter
+    # before_action :customer_only_filter
     #
     # rescue_from Cassette::Errors::NotACustomer do
     #   redirect_to '/403.html'

--- a/lib/cassette/authentication/filter.rb
+++ b/lib/cassette/authentication/filter.rb
@@ -9,13 +9,13 @@ module Cassette
       extend ActiveSupport::Concern
 
       included do |controller|
-        controller.before_filter(:validate_authentication_ticket)
+        controller.before_action(:validate_authentication_ticket)
         controller.send(:attr_accessor, :current_user)
       end
 
       module ClassMethods
         def skip_authentication(*options)
-          skip_before_filter :validate_authentication_ticket, *options
+          skip_before_action :validate_authentication_ticket, *options
         end
       end
 

--- a/lib/cassette/rubycas/helper.rb
+++ b/lib/cassette/rubycas/helper.rb
@@ -9,13 +9,13 @@ module Cassette
       include UserFactory
 
       included do
-        before_filter :validate_authentication_ticket
+        before_action :validate_authentication_ticket
         helper_method :current_user
       end
 
       module ClassMethods
         def skip_authentication(*options)
-          skip_before_filter :validate_authentication_ticket, *options
+          skip_before_action :validate_authentication_ticket, *options
         end
       end
 

--- a/lib/cassette/version.rb
+++ b/lib/cassette/version.rb
@@ -2,7 +2,7 @@ module Cassette
   class Version
     MAJOR = '1'
     MINOR = '1'
-    PATCH = '3'
+    PATCH = '4'
 
     def self.version
       [MAJOR, MINOR, PATCH].join('.')

--- a/spec/support/controllers/controller_mock.rb
+++ b/spec/support/controllers/controller_mock.rb
@@ -10,7 +10,7 @@ end
 
 class ControllerMock
   attr_accessor :params, :request, :current_user
-  def self.before_filter(*); end
+  def self.before_action(*); end
 
   def initialize(params = {}, headers = {})
     self.params = params.with_indifferent_access


### PR DESCRIPTION
Change `before_filter` to `before_action` due to a Rails 5 deprecation.

@rhruiz 