### PR TITLE
Changed ST validation request http method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
-All notable changes to this project will be documented in this file.
+All notable changes to this project will be documented in this file.  
 This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [1.2.1] - 2017-12-20
+### Changed
+- ST validation requests http method has been changed from POST to GET
 
 ## [1.2.0] - 2017-08-10
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cassette (1.2.0)
+    cassette (1.2.1)
       faraday (> 0.9)
 
 GEM
@@ -27,7 +27,7 @@ GEM
     docile (1.1.5)
     faker (1.4.3)
       i18n (~> 0.5)
-    faraday (0.9.2)
+    faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
     hashdiff (0.2.3)
     i18n (0.7.0)
@@ -115,4 +115,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.15.2
+   1.16.0

--- a/lib/cassette/authentication.rb
+++ b/lib/cassette/authentication.rb
@@ -31,7 +31,7 @@ module Cassette
         begin
           logger.info("Validating #{ticket} on #{validate_path}")
 
-          response = http.post(validate_path, ticket: ticket, service: service).body
+          response = http.get(validate_path, ticket: ticket, service: service).body
           ticket_response = Http::TicketResponse.new(response)
 
           logger.info("Validation resut: #{response.inspect}")

--- a/lib/cassette/http/request.rb
+++ b/lib/cassette/http/request.rb
@@ -17,6 +17,13 @@ module Cassette
         end
       end
 
+      def get(path, payload, timeout = DEFAULT_TIMEOUT)
+        perform(:get, path) do |req|
+          req.params = payload
+          req.options.timeout = timeout
+        end
+      end
+
       private
 
       attr_accessor :config

--- a/lib/cassette/version.rb
+++ b/lib/cassette/version.rb
@@ -2,7 +2,7 @@ module Cassette
   class Version
     MAJOR = '1'
     MINOR = '2'
-    PATCH = '0'
+    PATCH = '1'
 
     def self.version
       [MAJOR, MINOR, PATCH].join('.')

--- a/spec/cassette/authentication_spec.rb
+++ b/spec/cassette/authentication_spec.rb
@@ -45,13 +45,13 @@ describe Cassette::Authentication do
       end
 
       it 'raises a Forbidden exception on any exceptions' do
-        allow(http).to receive(:post).with(anything, anything).and_raise(Cassette::Errors::BadRequest)
+        allow(http).to receive(:get).with(anything, anything).and_raise(Cassette::Errors::BadRequest)
         expect { subject.ticket_user('ticket') }.to raise_error(Cassette::Errors::Forbidden)
       end
 
       context 'with a failed CAS response' do
         before do
-          allow(http).to receive(:post).with(anything, anything)
+          allow(http).to receive(:get).with(anything, anything)
             .and_return(OpenStruct.new(body: fixture('cas/fail.xml')))
         end
 
@@ -62,7 +62,7 @@ describe Cassette::Authentication do
 
       context 'with a successful CAS response' do
         before do
-          allow(http).to receive(:post).with(anything, anything)
+          allow(http).to receive(:get).with(anything, anything)
             .and_return(OpenStruct.new(body: fixture('cas/success.xml')))
         end
 


### PR DESCRIPTION
CAS release 5.1 just accepts GET http method on service validate path. This change is totally compatible with older releases of CAS because it accepts both GET and POST on service validate path.