### PR TITLE
Use a hash of the TGT to generate ST cache keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## UNRELEASED
+### Changed
+- ST caching now uses a hash of the TGT to avoid using `#delete_matched`
+
+### Fixed
+- Allow using memcached cache backends
+
 ## [1.2.4] - 2019-05-10
 ### Fixed
 - Make `Cassette::Cache.backend` assignable like the documentation says.

--- a/lib/cassette/client.rb
+++ b/lib/cassette/client.rb
@@ -30,8 +30,9 @@ module Cassette
 
     def st(tgt_param, service, force = false)
       logger.info "Requesting ST for #{service}"
-      cache.fetch_st(service, force: force) do
-        tgt = tgt_param.respond_to?(:call) ? tgt_param[] : tgt_param
+      tgt = tgt_param.respond_to?(:call) ? tgt_param[] : tgt_param
+
+      cache.fetch_st(tgt, service, force: force) do
         response = http.post("#{tickets_path}/#{tgt}", service: service)
         response.body.tap do |st|
           logger.info "ST is #{st}"

--- a/spec/cassette/client_spec.rb
+++ b/spec/cassette/client_spec.rb
@@ -160,7 +160,7 @@ describe Cassette::Client do
 
     context 'cache control' do
       before do
-        allow(cache).to receive(:fetch_st).with(service, hash_including(force: force))
+        allow(cache).to receive(:fetch_st).with(tgt, service, hash_including(force: force))
           .and_return(st)
       end
 
@@ -170,7 +170,7 @@ describe Cassette::Client do
         it 'forwards force to the cache' do
           subject
 
-          expect(cache).to have_received(:fetch_st).with(service, hash_including(force: force))
+          expect(cache).to have_received(:fetch_st).with(tgt, service, hash_including(force: force))
         end
       end
 
@@ -198,7 +198,7 @@ describe Cassette::Client do
     context 'when tgt and st are not cached' do
       before do
         allow(cache).to receive(:fetch_tgt).with(hash_including(force: false)).and_yield
-        allow(cache).to receive(:fetch_st).with(service, hash_including(force: false)).and_yield
+        allow(cache).to receive(:fetch_st).with(tgt, service, hash_including(force: false)).and_yield
 
         allow(http).to receive(:post)
           .with(%r{/v1/tickets\z}, username: Cassette.config.username, password: Cassette.config.password)
@@ -232,7 +232,7 @@ describe Cassette::Client do
     context 'when tgt is cached but st is not' do
       before do
         allow(cache).to receive(:fetch_tgt).with(hash_including(force: false)).and_return(tgt)
-        allow(cache).to receive(:fetch_st).with(service, hash_including(force: false)).and_yield
+        allow(cache).to receive(:fetch_st).with(tgt, service, hash_including(force: false)).and_yield
 
         allow(http).to receive(:post).with(%r{/v1/tickets/#{tgt}\z}, service: service)
           .and_return(st_response)
@@ -253,7 +253,8 @@ describe Cassette::Client do
 
     context 'when st is cached' do
       before do
-        allow(cache).to receive(:fetch_st).with(service, hash_including(force: false)).and_return(st)
+        allow(cache).to receive(:fetch_st).with(tgt, service, hash_including(force: false)).and_return(st)
+        allow(cache).to receive(:fetch_tgt).and_return(tgt)
       end
 
       it 'returns the cached value' do


### PR DESCRIPTION
By using a hash of the TGT to generate ST cache keys, everytime the TGT
changes all the cached STs are automatically expired and we can support
cache backends that do not implement '#delete_matched' like
Dalli/Memcache backends.

Fixes #30 