### PR TITLE
Fix cassette retro compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.2.7] - 2019-07-01
+### Fixed
+- Fix compatibility with the previous version when setting the cache
+
 ## [1.2.6] - 2019-06-27
 ### Fixed
 - Fix the way the cache backend is set and get to use the same one in everywhere

--- a/lib/cassette/cache.rb
+++ b/lib/cassette/cache.rb
@@ -33,6 +33,10 @@ module Cassette
       Cassette.cache_backend
     end
 
+    def backend=(backend)
+      Cassette.cache_backend = backend
+    end
+
     def self.backend=(backend)
       ::Cassette.cache_backend = backend
     end

--- a/spec/cassette/authentication/authorities_spec.rb
+++ b/spec/cassette/authentication/authorities_spec.rb
@@ -65,8 +65,9 @@ describe Cassette::Authentication::Authorities do
   end
 
   context 'with authentication disabled' do
-    before { ENV['NOAUTH'] = 'true' }
-    after { ENV.delete('NOAUTH') }
+    before do
+      stub_const('ENV', ENV.to_hash.merge('NOAUTH' => 'true'))
+    end
     subject { Cassette::Authentication::Authorities.new('[]') }
 
     it '#has_role? returns true for every role' do

--- a/spec/cassette/authentication/filter_spec.rb
+++ b/spec/cassette/authentication/filter_spec.rb
@@ -7,11 +7,7 @@ describe Cassette::Authentication::Filter do
 
   shared_context 'with NOAUTH' do
     before do
-      ENV['NOAUTH'] = 'yes'
-    end
-
-    after do
-      ENV.delete('NOAUTH')
+      stub_const('ENV', ENV.to_hash.merge('NOAUTH' => 'true'))
     end
   end
 

--- a/spec/cassette/client/cache_spec.rb
+++ b/spec/cassette/client/cache_spec.rb
@@ -4,18 +4,36 @@
 
 describe Cassette::Client::Cache do
   it 'uses the cache store set in configuration' do
+    # setup
+    global_cache = double('cache_store')
+    Cassette.cache_backend = global_cache
+
+    logger = Logger.new('/dev/null')
+
+    # exercise
+    client_cache = described_class.new(logger)
+
+    expect(client_cache.backend).to eq(global_cache)
+
+    # tear down
+    Cassette.cache_backend = nil
+  end
+
+  describe '.backend=' do
+    it 'sets the cache' do
       # setup
       global_cache = double('cache_store')
-      Cassette.cache_backend = global_cache
-
       logger = Logger.new('/dev/null')
 
       # exercise
-      client_cache = described_class.new(logger)
+      Cassette::Client.cache.backend = global_cache
 
-      expect(client_cache.backend).to eq(global_cache)
+      # verify
+      client_cache = described_class.new(logger)
+      expect(client_cache.backend).to eql(global_cache)
 
       # tear down
       Cassette.cache_backend = nil
     end
+  end
 end


### PR DESCRIPTION
## Motivation

The last version broke the compatibility with the previous versions when setting the cache backend.

The following code started to fail:
```ruby
Cassette::Client.cache.backend = SomeCacheBackend
```

## Proposed solution

Add the method `Cassette::Cache#backend=`

## Comment

I also fixed some broken specs which were failing with a specific seed. 

I think it is better to stub the const ENV when necessary than modifying it.