### PR TITLE
feat: improve logs to know when the TGT was cached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [unreleased]
+### Changed
+- Improve logs to know when the TGT was cached
+
 ## [1.2.7] - 2019-07-01
 ### Fixed
 - Fix compatibility with the previous version when setting the cache

--- a/lib/cassette/client/cache.rb
+++ b/lib/cassette/client/cache.rb
@@ -16,7 +16,7 @@ module Cassette
       def fetch_tgt(options = {}, &_block)
         options = { expires_in: 4 * 3600, max_uses: 5000, force: false }.merge(options)
         fetch('Cassette::Client.tgt', options) do
-          logger.info 'TGT is not cached'
+          logger.info('TGT cache miss')
           yield
         end
       end


### PR DESCRIPTION
## Motivation

When the TGT is cached, the logs are unclear about this:

![image](https://user-images.githubusercontent.com/302303/66129628-aa012d80-e5c6-11e9-9bc8-391401a38b2f.png)

## Proposed solution

- Add a log message to tell when the TGT was read from the cache.

```
INFO -- : Requesting TGT
INFO -- : TGT was cached with TGT-Something-example
```

- I also refactored/changed the way these tests are, using a more integrated approach (avoiding stubs and mocks).

## Comments

If you agree with the solution, I will send another PR with the same thing for the service-tickets!

cc @pmnhaes @rpaffaro
