### PR TITLE
Make the SSL_Verify and TLS Version version configurable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ after_script:
   - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi
 matrix:
   include:
-    - rvm: "1.9.3"
-      gemfile: Gemfile-old-ruby
     - rvm: "2.0.0"
       gemfile: Gemfile-old-ruby
     - rvm: "2.1.7"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [1.3.0] - 2020-03-19
+## [1.4.0] - 2020-03-19
+## [unreleased]
 ### Changed
 - Make the SSL_Verify and TLS Version version configurable
 
-## [1.2.????] - 2019-11-07
+## [1.3.0] - 2020-03-19
+### Changed
 - Improve logs to know when the TGT was cached
 
 ## [1.2.7] - 2019-07-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.3.0] - 2020-03-19
 ### Changed
+- Make the SSL_Verify and TLS Version version configurable
+
+## [1.2.????] - 2019-11-07
 - Improve logs to know when the TGT was cached
 
 ## [1.2.7] - 2019-07-01

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cassette (1.3.0)
+    cassette (1.4.0)
       faraday (> 0.9)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,7 @@ GEM
     docile (1.1.5)
     faker (1.6.6)
       i18n (~> 0.5)
-    faraday (1.0.0)
+    faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     hashdiff (0.3.7)
     i18n (0.9.1)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Cassete.config = OpenStruct.new(
 )
 ```
 
-where config is an object that responds to the methods `base` for the base CAS uri, `username` and `password` if you are authenticating on other systems and `service` and `base_authority` if you are using the authentication filter to authenticate your app.
+where config is an OpenStruct that responds to the methods `base` for the base CAS uri, `username` and `password` if you are authenticating on other systems and `service` and `base_authority` if you are using the authentication filter to authenticate your app.
 
 You may also set the caching backend using the .backend= module method:
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,15 @@ $ bundle
 Require this library and create an intializer to set its configuration:
 
 ```ruby
-Cassette.config = config
+Cassete.config = OpenStruct.new(
+  username: 'user',
+  password: 'secret',
+  service: 'test-api.example.org',
+  base: 'https://some-cas.example.org',
+  base_authority: 'CASTEST',
+  verify_ssl: true,       # If not defined, the default value will be: false.
+  tls_version: 'TLSv1_2'  # if not defined, the default value will be: 'TLSv1'.
+)
 ```
 
 where config is an object that responds to the methods `base` for the base CAS uri, `username` and `password` if you are authenticating on other systems and `service` and `base_authority` if you are using the authentication filter to authenticate your app.

--- a/lib/cassette.rb
+++ b/lib/cassette.rb
@@ -21,7 +21,9 @@ module Cassette
 
   attr_writer :config, :logger
 
-  DEFAULT_TIMEOUT = 10
+  DEFAULT_TIMEOUT     = 10
+  DEFAULT_TLS_VERSION = 'TLSv1'.freeze
+  DEFAULT_VERIFY_SSL  = false
 
   def logger
     @logger ||= begin
@@ -35,6 +37,12 @@ module Cassette
 
   def config
     @config if defined?(@config)
+
+    @config.tls_version = DEFAULT_TLS_VERSION if @config.tls_version.nil?
+
+    @config.verify_ssl = DEFAULT_VERIFY_SSL if @config.verify_ssl.nil?
+
+    @config
   end
 
   def cache_backend

--- a/lib/cassette/http/request.rb
+++ b/lib/cassette/http/request.rb
@@ -36,7 +36,8 @@ module Cassette
       end
 
       def request
-        @request ||= Faraday.new(url: config.base, ssl: { verify: false, version: 'TLSv1' }) do |conn|
+        @request ||= Faraday.new(url: config.base, ssl:
+          { verify: config.verify_ssl, version: config.tls_version }) do |conn|
           conn.adapter Faraday.default_adapter
         end
       end

--- a/lib/cassette/version.rb
+++ b/lib/cassette/version.rb
@@ -1,8 +1,8 @@
 module Cassette
   class Version
-    MAJOR = '1'
-    MINOR = '4'
-    PATCH = '0'
+    MAJOR = '1'.freeze
+    MINOR = '4'.freeze
+    PATCH = '0'.freeze
 
     def self.version
       [MAJOR, MINOR, PATCH].join('.')

--- a/lib/cassette/version.rb
+++ b/lib/cassette/version.rb
@@ -1,7 +1,7 @@
 module Cassette
   class Version
     MAJOR = '1'
-    MINOR = '3'
+    MINOR = '4'
     PATCH = '0'
 
     def self.version

--- a/spec/cassette_spec.rb
+++ b/spec/cassette_spec.rb
@@ -7,6 +7,78 @@ describe Cassette do
     Cassette.logger = original_logger
   end
 
+  describe '.config' do
+    it 'defines Cassette initial configuration based on a OpenStruct' do
+
+      config = OpenStruct.new(
+        YAML.load_file('spec/config.yml')
+      )
+
+      Cassette.config = config
+
+      expect(Cassette.config)
+        .to eq(config)
+    end
+
+    context 'when tls_version was not specified' do
+      it 'uses default TLS version: TLSv1' do
+        config = OpenStruct.new(
+          YAML.load_file('spec/config.yml')
+        )
+
+        # Removing tls_version field
+        config.delete_field(:tls_version)
+
+        Cassette.config = config
+
+        expect(Cassette.config.tls_version)
+          .to eq('TLSv1')
+      end
+    end
+
+    context 'when tls_version is specified' do
+      it 'uses this version' do
+        config = OpenStruct.new(
+          YAML.load_file('spec/config.yml')
+        )
+
+        Cassette.config = config
+
+        expect(Cassette.config.tls_version)
+          .to eq('TLSv1_2')
+      end
+    end
+
+    context 'when verify_ssl was not specified' do
+      it 'uses default verify_ssl value: false' do
+        config = OpenStruct.new(
+          YAML.load_file('spec/config.yml')
+        )
+
+        # Removing verify_ssl field
+        config.delete_field(:verify_ssl)
+
+        Cassette.config = config
+
+        expect(Cassette.config.verify_ssl)
+          .to be false
+      end
+    end
+
+    context 'when verify_ssl is specified' do
+      it 'uses this value' do
+        config = OpenStruct.new(
+          YAML.load_file('spec/config.yml')
+        )
+
+        Cassette.config = config
+
+        expect(Cassette.config.verify_ssl)
+          .to be true
+      end
+    end
+  end
+
   describe '.logger' do
     it 'returns a default instance' do
       expect(Cassette.logger).not_to be_nil

--- a/spec/config.yml
+++ b/spec/config.yml
@@ -1,7 +1,7 @@
-username: "user"
-password: "secret"
-service: "test-api.example.org"
-base: "https://some-cas.example.org"
-base_authority: "CASTEST"
+username: 'user'
+password: 'secret'
+service: 'test-api.example.org'
+base: 'https://some-cas.example.org'
+base_authority: 'CASTEST'
 verify_ssl: true
 tls_version: 'TLSv1_2'

--- a/spec/config.yml
+++ b/spec/config.yml
@@ -3,3 +3,5 @@ password: "secret"
 service: "test-api.example.org"
 base: "https://some-cas.example.org"
 base_authority: "CASTEST"
+verify_ssl: true
+tls_version: 'TLSv1_2'


### PR DESCRIPTION
**Motivation**

To avoid TLS problems that can happen because of lower versions, we need to update the version of TLS that is being passed in the requests created by Faraday.

```
@request || = Faraday.new (url: config.base, ssl: { verify: false, version: 'TLSv1' }) do | conn |
         
```

Many sites are no longer accepting requests with TLSv1, and are now accepting only TLSv1_2 or higher.

In addition, the use of SSL in requests needs to be configured dynamically, where we are currently setting the code together with TLS.

To simulate this case, the tests below were done pointing to a URL that needs TLS greater than version 1.0:

_TLSv1 (Failure)_

```ruby
request = Faraday.new(url: 'https://www.entrustdatacard.com/', ssl: { verify: false, version: 'TLSv1' })

request.get('/').success?

>> Faraday::SSLError: SSL_connect returned=1 errno=0 state=error: tlsv1 alert protocol version
  from /home/rogerssonsouza/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/net/protocol.rb:44:in `connect_nonblock'
  from /home/rogerssonsouza/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/net/protocol.rb:44:in `ssl_socket_connect'
  from /home/rogerssonsouza/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/net/http.rb:948:in `connect'
  from /home/rogerssonsouza/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/net/http.rb:887:in `do_start'
  from /home/rogerssonsouza/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/net/http.rb:876:in `start'
  from /home/rogerssonsouza/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/net/http.rb:1407:in `request'
  from /home/rogerssonsouza/.rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/net/http.rb:1165:in `get'
```

_TLSv1_2 (Success)_

```ruby
request = Faraday.new(url: 'https://www.entrustdatacard.com/', ssl: { verify: false, version: 'TLSv1_2' })

request.get('/').success?
=> true
```

**Proposed solution**

- Creation of tests of the .config method of the Cassette.rb module to guarantee the current functioning.

- Receive the TLS version and SSL Verification parameters in the initial Cassette configuration.

- Use the default settings of TLSv1 and SSL false when not specified in the configuration

**Comment**

I realized that the latest version in the CHANGELOG.md file is [1.2.7] - 2019-07-01, but the Pull Request "Improve logs to know when the TGT was cached" was accepted after it and apparently has no version.

Which version should I specify?