### PR TITLE
update default tls version and add safe navigators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [1.4.0] - 2020-03-19
+## [1.5.0] - 2020-06-22
 ## [unreleased]
+### Changed
+- Make TLS default Version 1.2
+- Fix Cassette::Client instance creation without default configuration
+
+## [1.4.0] - 2020-03-19
 ### Changed
 - Make the SSL_Verify and TLS Version version configurable
 

--- a/lib/cassette.rb
+++ b/lib/cassette.rb
@@ -14,6 +14,7 @@ require 'cassette/authentication/filter'
 require 'faraday'
 require 'forwardable'
 require 'logger'
+require 'ostruct'
 
 module Cassette
   extend Forwardable
@@ -36,11 +37,11 @@ module Cassette
   end
 
   def config
-    @config if defined?(@config)
+    @config = OpenStruct.new unless defined?(@config)
 
-    @config.tls_version = DEFAULT_TLS_VERSION if @config&.tls_version.nil?
+    @config.tls_version = DEFAULT_TLS_VERSION if @config.tls_version.nil?
 
-    @config.verify_ssl = DEFAULT_VERIFY_SSL if @config&.verify_ssl.nil?
+    @config.verify_ssl = DEFAULT_VERIFY_SSL if @config.verify_ssl.nil?
 
     @config
   end

--- a/lib/cassette.rb
+++ b/lib/cassette.rb
@@ -22,7 +22,7 @@ module Cassette
   attr_writer :config, :logger
 
   DEFAULT_TIMEOUT     = 10
-  DEFAULT_TLS_VERSION = 'TLSv1'.freeze
+  DEFAULT_TLS_VERSION = 'TLSv1_2'.freeze
   DEFAULT_VERIFY_SSL  = false
 
   def logger
@@ -38,9 +38,9 @@ module Cassette
   def config
     @config if defined?(@config)
 
-    @config.tls_version = DEFAULT_TLS_VERSION if @config.tls_version.nil?
+    @config.tls_version = DEFAULT_TLS_VERSION if @config&.tls_version.nil?
 
-    @config.verify_ssl = DEFAULT_VERIFY_SSL if @config.verify_ssl.nil?
+    @config.verify_ssl = DEFAULT_VERIFY_SSL if @config&.verify_ssl.nil?
 
     @config
   end

--- a/lib/cassette/version.rb
+++ b/lib/cassette/version.rb
@@ -1,7 +1,7 @@
 module Cassette
   class Version
     MAJOR = '1'.freeze
-    MINOR = '4'.freeze
+    MINOR = '5'.freeze
     PATCH = '0'.freeze
 
     def self.version

--- a/spec/cassette_spec.rb
+++ b/spec/cassette_spec.rb
@@ -21,7 +21,7 @@ describe Cassette do
     end
 
     context 'when tls_version was not specified' do
-      it 'uses default TLS version: TLSv1' do
+      it 'uses default TLS version: TLSv1_2' do
         config = OpenStruct.new(
           YAML.load_file('spec/config.yml')
         )
@@ -32,7 +32,7 @@ describe Cassette do
         Cassette.config = config
 
         expect(Cassette.config.tls_version)
-          .to eq('TLSv1')
+          .to eq('TLSv1_2')
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ require 'webmock/rspec'
 require 'rspec/its'
 require 'faker'
 if RUBY_VERSION >= '2.3.0'
-  require 'pry-byebug'
+  # require 'pry-byebug'
 end
 
 Dir['spec/support/**/*.rb'].each { |f| load f }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ require 'webmock/rspec'
 require 'rspec/its'
 require 'faker'
 if RUBY_VERSION >= '2.3.0'
-  # require 'pry-byebug'
+  require 'pry-byebug'
 end
 
 Dir['spec/support/**/*.rb'].each { |f| load f }


### PR DESCRIPTION
# Motivation
After updating my OS from ubuntu 18.04 to 20.04 I've started to have problems using the `locaweb_tools` gem. So, to solve this problem I've investigated a bit and found that the TLS version was causing problems with the SSL.

# Solution
I've updated the default TLS version to 1.2, also I've made a minor fix to allow instantiate a new Cassette::Client object when there is no default config set.
