### PR TITLE
Fix when cas_extra_attributes keys are string

### DIFF
--- a/lib/cassette/rubycas/user_factory.rb
+++ b/lib/cassette/rubycas/user_factory.rb
@@ -3,6 +3,7 @@ module Cassette
     module UserFactory
       def from_session(session)
         attributes = session[:cas_extra_attributes]
+        attributes = attributes.with_indifferent_access if attributes.respond_to?(:with_indifferent_access)
         Cassette::Authentication::User.new(login: session[:cas_user],
                                            name: attributes.try(:[], :cn),
                                            email: attributes.try(:[], :email),

--- a/spec/cassette/authentication/user_factory_spec.rb
+++ b/spec/cassette/authentication/user_factory_spec.rb
@@ -38,5 +38,27 @@ RSpec.describe Cassette::Rubycas::UserFactory do
       it { is_expected.to be_customer }
       it { is_expected.not_to be_employee }
     end
+
+    context 'when key cas_extra_attributes is string' do
+      let(:session) do
+        name = Faker.name
+
+        {
+          cas_user: Faker::Internet.user_name(name),
+          cas_extra_attributes: {
+            'email' => Faker::Internet.email(name),
+            'type' => 'Customer',
+            'authorities' => '[CASTEST_ADMIN]'
+          }
+        }
+      end
+
+      its(:login) { is_expected.to eq(session[:cas_user]) }
+      its(:name) { is_expected.to eq(attributes['name']) }
+      its(:email) { is_expected.to eq(attributes['email']) }
+      its(:type) { is_expected.to eq(attributes['type'].downcase) }
+      it { is_expected.to be_customer }
+      it { is_expected.not_to be_employee }
+    end
   end
 end


### PR DESCRIPTION
When cas_extra_attributes keys were string, the attributes were not loaded