### PR TITLE
Provide a way to fetch all ticket attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## UNRELEASED
 
+### Added
+- Provide `Cassette::Authentication::User#attribute` to fetch generic attributes
+  from the user in the ticket validation response
+
 ## [1.6.0] - 2020-11-26
 ### Changed
 - Make `cas_extra_attributes` accessible as strings or symbols when restoring

--- a/lib/cassette/authentication.rb
+++ b/lib/cassette/authentication.rb
@@ -36,13 +36,17 @@ module Cassette
 
           logger.info("Validation resut: #{response.inspect}")
 
-          Cassette::Authentication::User.new(
-            login: ticket_response.login,
-            name: ticket_response.name,
-            authorities: ticket_response.authorities,
-            ticket: ticket,
-            config: config
-          ) if ticket_response.login
+          if ticket_response.login
+            attributes = ticket_response.attributes.dup.merge(
+              login: ticket_response.login,
+              name: ticket_response.name,
+              authorities: ticket_response.authorities,
+              ticket: ticket,
+              config: config
+            )
+
+            Cassette::Authentication::User.new(attributes)
+          end
         rescue => exception
           logger.error "Error while authenticating ticket #{ticket}: #{exception.message}"
           raise Cassette::Errors::Forbidden, exception.message

--- a/lib/cassette/authentication/user.rb
+++ b/lib/cassette/authentication/user.rb
@@ -19,8 +19,13 @@ module Cassette
         @type        = attrs[:type]
         @email       = attrs[:email]
         @ticket      = attrs[:ticket]
+        @attributes  = attrs
         @authorities = Cassette::Authentication::Authorities
                        .parse(attrs.fetch(:authorities, '[]'), config && config.base_authority)
+      end
+
+      def attribute(key)
+        @attributes[key]
       end
 
       %w(customer employee).each do |type|

--- a/lib/cassette/http/ticket_response.rb
+++ b/lib/cassette/http/ticket_response.rb
@@ -4,7 +4,7 @@ require 'rexml/xpath'
 module Cassette
   module Http
     class TicketResponse
-      attr_reader :login, :name, :authorities
+      attr_reader :login, :name, :authorities, :attributes
 
       def initialize(response)
         namespaces = { "cas" => "http://www.yale.edu/tp/cas" }
@@ -22,8 +22,9 @@ module Cassette
             elements.
             map { |e| [e.name, e.text] }]
 
-          @name = attributes['cn']
-          @authorities = attributes['authorities']
+          @name = attributes.delete('cn')
+          @authorities = attributes.delete('authorities')
+          @attributes = attributes
         end
       end
     end

--- a/spec/cassette/authentication/user_spec.rb
+++ b/spec/cassette/authentication/user_spec.rb
@@ -24,6 +24,52 @@ describe Cassette::Authentication::User do
                                            authorities: '[CUSTOMERAPI, SAPI]', config: config)
       end
     end
+
+    context 'attributes' do
+      it 'takes login from the attributes' do
+        user = described_class.new(login: 'john.doe')
+
+        expect(user.login).to eql('john.doe')
+      end
+
+      it 'takes name from the attributes' do
+        user = described_class.new(name: 'John Doe')
+
+        expect(user.name).to eql('John Doe')
+      end
+    end
+  end
+
+  describe '#attribute' do
+    it 'returns attributes given to the user' do
+      user = described_class.new(
+        login: 'john.doe',
+        name: 'John Doe',
+        attributes: { 'attribute' => 'something' }
+      )
+
+      expect(user.attribute('attribute')).to eql('something')
+    end
+
+    it 'retuns nil for attributes not given to the user' do
+      user = described_class.new(
+        login: 'john.doe',
+        name: 'John Doe',
+        attributes: { 'attribute' => 'something' }
+      )
+
+      expect(user.attribute('other_attribute')).to be_nil
+    end
+
+    it 'does not return attributes that are already extracted' do
+      user = described_class.new(
+        login: 'john.doe',
+        name: 'John Doe',
+        attributes: { 'attribute' => 'something' }
+      )
+
+      expect(user.attribute('login')).to be_nil
+    end
   end
 
   describe '#has_role?' do

--- a/spec/cassette/authentication_spec.rb
+++ b/spec/cassette/authentication_spec.rb
@@ -69,6 +69,12 @@ describe Cassette::Authentication do
         it 'returns an User' do
           expect(ticket_user).to be_instance_of(Cassette::Authentication::User)
         end
+
+        it 'sets attributes from the ticket response' do
+          expect(ticket_user.login).to eql('test-user')
+          expect(ticket_user.name).to eql('Test System')
+          expect(ticket_user.attribute('type')).to eql('system')
+        end
       end
     end
   end

--- a/spec/cassette/http/ticket_response_spec.rb
+++ b/spec/cassette/http/ticket_response_spec.rb
@@ -38,4 +38,22 @@ describe Cassette::Http::TicketResponse do
       it { is_expected.to be_nil }
     end
   end
+
+  describe '#attributes' do
+    subject(:attributes) { ticket_response.attributes }
+
+    context 'when response is successful' do
+      let(:xml_response) { fixture('cas/success.xml') }
+
+      it 'returns the attributes not already extracted' do
+        expect(subject).to eq('type' => 'System', 'attribute' => 'something')
+      end
+    end
+
+    context 'when response is not successful' do
+      let(:xml_response) { fixture('cas/fail.xml') }
+
+      it { is_expected.to be_nil }
+    end
+  end
 end

--- a/spec/fixtures/cas/success.xml
+++ b/spec/fixtures/cas/success.xml
@@ -6,6 +6,8 @@
     <cas:attributes>
       <cas:authorities>[CUPOM, AUDITING,]</cas:authorities>
       <cas:cn>Test System</cas:cn>
+      <cas:type>System</cas:type>
+      <cas:attribute>something</cas:attribute>
     </cas:attributes>
     <!-- End Ldap Attributes -->
     </cas:authenticationSuccess>


### PR DESCRIPTION
Currently only a few of the user attributes are parsed in the ticket response and set in the Cassette::Authentication::User instance.

This PR provides a way to fetch any attribute in the ticket response that is not a special case already handled