### PR TITLE
Assign know user attributes from extra_attributes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Ruby, bundler and dependencies
         uses: ruby/setup-ruby@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## UNRELEASED
 
+### Added
+- Assign know user attributes from extra_attributes
+
 ## [1.7.0] - 2023-07-12
 ### Added
 - Make CAS extra attributes available in `Cas::Authentication::User`

--- a/lib/cassette/authentication/user.rb
+++ b/lib/cassette/authentication/user.rb
@@ -21,10 +21,15 @@ module Cassette
         @type             = attrs[:type]
         @email            = attrs[:email]
         @ticket           = attrs[:ticket]
-        @extra_attributes = attrs[:extra_attributes]
         @authorities      = Cassette::Authentication::Authorities
                             .parse(attrs.fetch(:authorities, '[]'),
                                    config&.base_authority)
+        @extra_attributes = attrs[:extra_attributes] || {}
+        @extra_attributes.each_pair do |key, value|
+          if respond_to?("#{key}=")
+            send("#{key}=", value)
+          end
+        end
       end
 
       %w(customer employee).each do |type|

--- a/lib/cassette/authentication/user.rb
+++ b/lib/cassette/authentication/user.rb
@@ -27,7 +27,7 @@ module Cassette
         @extra_attributes = attrs[:extra_attributes] || {}
         @extra_attributes.each_pair do |key, value|
           if respond_to?("#{key}=")
-            send("#{key}=", value)
+            public_send("#{key}=", value)
           end
         end
       end

--- a/spec/cassette/authentication/user_factory_spec.rb
+++ b/spec/cassette/authentication/user_factory_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe Cassette::Rubycas::UserFactory do
       name = Faker.name
 
       {
-        cas_user: Faker::Internet.user_name(name),
+        cas_user: Faker::Internet.user_name(specifier: name),
         cas_extra_attributes: {
-          email: Faker::Internet.email(name),
+          email: Faker::Internet.email(name: name),
           type: 'Customer',
           authorities: '[CASTEST_ADMIN]',
           extra: 'some value'
@@ -49,9 +49,9 @@ RSpec.describe Cassette::Rubycas::UserFactory do
         name = Faker.name
 
         {
-          cas_user: Faker::Internet.user_name(name),
+          cas_user: Faker::Internet.user_name(specifier: name),
           cas_extra_attributes: {
-            'email' => Faker::Internet.email(name),
+            'email' => Faker::Internet.email(name: name),
             'type' => 'Customer',
             'authorities' => '[CASTEST_ADMIN]'
           }

--- a/spec/cassette/authentication/user_spec.rb
+++ b/spec/cassette/authentication/user_spec.rb
@@ -24,6 +24,20 @@ describe Cassette::Authentication::User do
                                            authorities: '[CUSTOMERAPI, SAPI]', config: config)
       end
     end
+
+    context 'with extra attributes' do
+      it 'sets attributes that user responds to' do
+        user = Cassette::Authentication::User.new(login: 'john.doe', extra_attributes: { 'type' => 'employee' })
+
+        expect(user.type).to eq('employee')
+      end
+
+      it 'lets extra_attributes override other arguments' do
+        user = Cassette::Authentication::User.new(name: 'John Doe', extra_attributes: { 'name' => 'Jane Doe' })
+
+        expect(user.name).to eq('Jane Doe')
+      end
+    end
   end
 
   describe '#has_role?' do


### PR DESCRIPTION
Allows that common attributes like `type`, `email` etc be configured either directly in the constructor hash or in `extra_attributes` like when returning from the ticket validation:

```ruby
user = Cassette::Authentication::User.new(email: "user@example.com")
user.email
=> "user@example.com"
```

From the ticket validation, assuming `<cas:attributes><cas:email>user@example.com</cas:email></cas:attributes>` in the response:

```ruby
user = Cassette::Authentication::User.new(extra_attributes: {"email" =>  "user@example.com"})
user.email
=> "user@example.com"
```
